### PR TITLE
Fix npm registry URL in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
-          registry-url: 'https://registry.npmjs.org/'
+          registry-url: 'https://registry.npmjs.org'
 
       - name: Install deps
         run: npm ci


### PR DESCRIPTION
Removed trailing slash from npm registry URL.

## Description
<!--- Describe your changes -->

## Changes
<!--- What types of changes does your code introduce? -->
