### PR TITLE
Feat/cookies

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,14 +5,15 @@ on:
     branches:
       - main
     tags:
-      - 'v*.*.*' # Trigger on version tags like v1.0.0
+      - 'v*.*.*'
 
 jobs:
   publish:
+    runs-on: ubuntu-latest
+
     permissions:
       contents: read
-      id-token: write # 🔥 required for OIDC
-    runs-on: ubuntu-latest
+      id-token: write
 
     steps:
       - name: Checkout code
@@ -22,12 +23,12 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
-          registry-url: 'https://registry.npmjs.org/'
-      
-      - name: Update npm to latest
+          registry-url: https://registry.npmjs.org/
+
+      - name: Update npm
         run: npm install -g npm@latest
 
-      - name: Install deps
+      - name: Install dependencies
         run: npm ci
 
       - name: Run tests
@@ -36,7 +37,5 @@ jobs:
       - name: Build
         run: npm run build --if-present
 
-      - name: Publish package
+      - name: Publish to npm (OIDC)
         run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ideashift/nestjs-passport-firebase",
-  "version": "1.0.14",
+  "version": "1.0.15",
   "description": "Passport - Firebase Auth Module for NestJS",
   "author": "IdeaShift IN",
   "license": "MIT",


### PR DESCRIPTION
## Description
<!--- Describe your changes -->

## Changes
This pull request updates the npm package version and refines the GitHub Actions workflow for publishing to npm. The main focus is on improving clarity in workflow step names, ensuring correct configuration for publishing with OIDC authentication, and removing unused environment variables.

Workflow improvements in `.github/workflows/publish.yml`:

* Added `runs-on: ubuntu-latest` at the correct level for the `publish` job and removed redundant lines for cleaner workflow configuration.
* Updated step names for clarity (e.g., "Update npm" and "Install dependencies"), and removed unnecessary quotes in the `registry-url` value.
* Changed the publish step name to "Publish to npm (OIDC)", removed the unused `NODE_AUTH_TOKEN` environment variable, and ensured publishing uses OIDC authentication.

Version bump:

* Updated the package version in `package.json` from `1.0.14` to `1.0.15` to reflect the new release.
